### PR TITLE
Add simple token-based login API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+## API Authentication
+
+Set `API_KEY` in your `.env` file.
+
+Use `POST /api/login` with `email` and `password` to obtain a token.
+Send the token in the `Authorization: Bearer <token>` header for subsequent API requests.

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AuthController extends Controller
+{
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $user = User::where('email', $credentials['email'])->first();
+
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $hash = hash_hmac('sha256', $user->email, env('API_KEY'));
+        $token = base64_encode($user->id.'|'.$hash);
+
+        return response()->json(['token' => $token]);
+    }
+}

--- a/app/Http/Middleware/TokenAuth.php
+++ b/app/Http/Middleware/TokenAuth.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class TokenAuth
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $header = $request->header('Authorization');
+
+        if (! $header || ! str_starts_with($header, 'Bearer ')) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $decoded = base64_decode(substr($header, 7));
+        if (! $decoded || ! str_contains($decoded, '|')) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        [$id, $hash] = explode('|', $decoded, 2);
+        $user = User::find($id);
+        if (! $user) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $expected = hash_hmac('sha256', $user->email, env('API_KEY'));
+        if (! hash_equals($expected, $hash)) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $request->setUserResolver(fn () => $user);
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+use App\Http\Middleware\TokenAuth;
+
+Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware(TokenAuth::class)->group(function () {
+    Route::get('/user', function (Request $request) {
+        return response()->json($request->user());
+    });
+});


### PR DESCRIPTION
## Summary
- implement `AuthController` to authenticate users and return a token
- add `TokenAuth` middleware to validate the provided token
- create `routes/api.php` with login and user routes
- register API routes in the application bootstrap
- document basic API usage in README

## Testing
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730c074530832f9303159e26c6e3f5