### PR TITLE
Require API key on login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,6 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# API token generation key
+API_KEY=

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ The Laravel framework is open-sourced software licensed under the [MIT license](
 
 Set `API_KEY` in your `.env` file.
 
-Use `POST /api/login` with `email` and `password` to obtain a token.
+Use `POST /api/login` with `email` and `password` and include the `X-API-Key` header to obtain a token.
 Send the token in the `Authorization: Bearer <token>` header for subsequent API requests.

--- a/app/Http/Middleware/CheckApiKey.php
+++ b/app/Http/Middleware/CheckApiKey.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckApiKey
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $key = $request->header('x-api-key');
+        if (! $key || $key !== env('API_KEY')) {
+            return response()->json(['message' => 'Invalid API key'], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,8 +4,9 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Middleware\TokenAuth;
+use App\Http\Middleware\CheckApiKey;
 
-Route::post('/login', [AuthController::class, 'login']);
+Route::post('/login', [AuthController::class, 'login'])->middleware(CheckApiKey::class);
 
 Route::middleware(TokenAuth::class)->group(function () {
     Route::get('/user', function (Request $request) {


### PR DESCRIPTION
## Summary
- add API key middleware
- secure login route with API key middleware
- document X-API-Key requirement
- show `API_KEY` variable in env example

## Testing
- `php artisan test` *(fails: php not installed)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68731258dab0832fb3f0ce17dcc1585b