### PR TITLE
Add categories API endpoint

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
+
+class CategoryController extends Controller
+{
+    public function index()
+    {
+        $categories = DB::table('juego_categoria')
+            ->select('id', 'nombre', 'icono', 'estado')
+            ->where('estado', 1)
+            ->get();
+
+        return response()->json($categories);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Middleware\TokenAuth;
 use App\Http\Middleware\CheckApiKey;
+use App\Http\Controllers\CategoryController;
 
 Route::post('/login', [AuthController::class, 'login'])->middleware(CheckApiKey::class);
 
@@ -12,4 +13,5 @@ Route::middleware(TokenAuth::class)->group(function () {
     Route::get('/user', function (Request $request) {
         return response()->json($request->user());
     });
+    Route::get('/categories', [CategoryController::class, 'index']);
 });


### PR DESCRIPTION
## Summary
- implement `CategoryController` with DB query to load enabled categories
- register `/categories` route in `routes/api.php`

## Testing
- `composer test` *(fails: cannot find vendor)*

------
https://chatgpt.com/codex/tasks/task_e_6873174834b8832fb8794c1192387ef0