### PR TITLE
Make categories route public

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -10,9 +10,10 @@ use App\Http\Controllers\CategoryController;
 Route::post('/login', [AuthController::class, 'login'])->middleware(CheckApiKey::class);
 Route::post('/login-usuarios', [AuthController::class, 'loginUsuarios'])->middleware(CheckApiKey::class);
 
+Route::get('/categories', [CategoryController::class, 'index']);
+
 Route::middleware(TokenAuth::class)->group(function () {
     Route::get('/user', function (Request $request) {
         return response()->json($request->user());
     });
-    Route::get('/categories', [CategoryController::class, 'index']);
 });


### PR DESCRIPTION
## Summary
- expose `/categories` API without auth middleware

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `composer test` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_68731cee04d4832f8c5213ed69d769b3