### PR TITLE
Add JWT session auth

### DIFF
--- a/app/Http/Middleware/TokenAuth.php
+++ b/app/Http/Middleware/TokenAuth.php
@@ -3,37 +3,45 @@
 namespace App\Http\Middleware;
 
 use App\Models\User;
+use App\Models\UserSession;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Carbon\Carbon;
 
 class TokenAuth
 {
-    /**
-     * Handle an incoming request.
-     */
     public function handle(Request $request, Closure $next): Response
     {
-        $header = $request->header('Authorization');
-
-        if (! $header || ! str_starts_with($header, 'Bearer ')) {
-            return response()->json(['message' => 'Unauthenticated'], 401);
+        $token = $request->bearerToken();
+        if (! $token) {
+            return response()->json(['message' => 'Unauthenticated', 'requires_new_token' => true], 401);
         }
 
-        $decoded = base64_decode(substr($header, 7));
-        if (! $decoded || ! str_contains($decoded, '|')) {
-            return response()->json(['message' => 'Unauthenticated'], 401);
+        try {
+            $payload = JWT::decode($token, new Key(env('APP_KEY'), 'HS256'));
+        } catch (\Firebase\JWT\ExpiredException $e) {
+            return response()->json(['message' => 'Token expired', 'requires_new_token' => true], 401);
+        } catch (\Exception $e) {
+            return response()->json(['message' => 'Unauthenticated', 'requires_new_token' => true], 401);
         }
 
-        [$id, $hash] = explode('|', $decoded, 2);
-        $user = User::find($id);
+        $session = UserSession::where('token', $token)->where('estado', 1)->first();
+        if (! $session) {
+            return response()->json(['message' => 'Unauthenticated', 'requires_new_token' => true], 401);
+        }
+
+        if (Carbon::parse($session->fecha_creacion)->addHour()->isPast()) {
+            $session->estado = 0;
+            $session->save();
+            return response()->json(['message' => 'Token expired', 'requires_new_token' => true], 401);
+        }
+
+        $user = User::find($payload->sub);
         if (! $user) {
-            return response()->json(['message' => 'Unauthenticated'], 401);
-        }
-
-        $expected = hash_hmac('sha256', $user->correo_usuario, env('API_KEY'));
-        if (! hash_equals($expected, $hash)) {
-            return response()->json(['message' => 'Unauthenticated'], 401);
+            return response()->json(['message' => 'Unauthenticated', 'requires_new_token' => true], 401);
         }
 
         $request->setUserResolver(fn () => $user);

--- a/app/Models/UserSession.php
+++ b/app/Models/UserSession.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserSession extends Model
+{
+    protected $table = 'usuarios_sesiones';
+    public $timestamps = false;
+    protected $fillable = [
+        'uuid_usuario',
+        'token',
+        'fecha_creacion',
+        'estado',
+    ];
+}

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "firebase/php-jwt": "^6.11",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1",
-        "firebase/php-jwt": "^6.10"
+        "laravel/tinker": "^2.10.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "firebase/php-jwt": "^6.10"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88970a0117c062eed55fa8728fc43833",
+    "content-hash": "bb43516eae1e73202940191fe341f64a",
     "packages": [
         {
             "name": "brick/math",
@@ -509,6 +509,69 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+            },
+            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/database/migrations/2025_07_13_000000_create_usuarios_sesiones_table.php
+++ b/database/migrations/2025_07_13_000000_create_usuarios_sesiones_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('usuarios_sesiones', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid_usuario');
+            $table->text('token');
+            $table->dateTime('fecha_creacion');
+            $table->boolean('estado')->default(1);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('usuarios_sesiones');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\CategoryController;
 
 Route::post('/login', [AuthController::class, 'login'])->middleware(CheckApiKey::class);
 Route::post('/login-usuarios', [AuthController::class, 'loginUsuarios'])->middleware(CheckApiKey::class);
+Route::post('/refresh-token', [AuthController::class, 'refreshToken']);
 
 Route::get('/categories', [CategoryController::class, 'index'])
     ->middleware(TokenAuth::class);


### PR DESCRIPTION
## Summary
- add JWT-based auth with one-hour tokens
- store tokens in `usuarios_sesiones`
- allow refreshing tokens
- update middleware to validate JWT tokens
- add dependency on firebase/php-jwt
- add migration and model for user sessions

## Testing
- `composer install --no-interaction` *(fails: firebase/php-jwt missing in lock file)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68732efc98ac832fbf2cf787a665a77b