### PR TITLE
Add niveles API

### DIFF
--- a/app/Http/Controllers/LevelController.php
+++ b/app/Http/Controllers/LevelController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+
+class LevelController extends Controller
+{
+    public function index()
+    {
+        $levels = DB::table('juego_dificultad')
+            ->select('id', 'nombre')
+            ->where('estado', 1)
+            ->get();
+
+        return response()->json($levels);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,12 +6,15 @@ use App\Http\Controllers\AuthController;
 use App\Http\Middleware\TokenAuth;
 use App\Http\Middleware\CheckApiKey;
 use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\LevelController;
 
 Route::post('/login', [AuthController::class, 'login'])->middleware(CheckApiKey::class);
 Route::post('/login-usuarios', [AuthController::class, 'loginUsuarios'])->middleware(CheckApiKey::class);
 Route::post('/refresh-token', [AuthController::class, 'refreshToken']);
 
 Route::get('/categories', [CategoryController::class, 'index'])
+    ->middleware(TokenAuth::class);
+Route::get('/niveles', [LevelController::class, 'index'])
     ->middleware(TokenAuth::class);
 
 Route::middleware(TokenAuth::class)->group(function () {


### PR DESCRIPTION
## Summary
- implement `LevelController` to list levels
- expose `/niveles` GET route

## Testing
- `php artisan test` *(fails: vendor autoload missing)*
- `composer install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873345ac43c832f875b67c03a3e3e3c