### PR TITLE
Add question creation endpoint

### DIFF
--- a/database/migrations/2025_07_13_000001_create_juego_preguntas_table.php
+++ b/database/migrations/2025_07_13_000001_create_juego_preguntas_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('juego_preguntas', function (Blueprint $table) {
+            $table->id();
+            $table->integer('categoria');
+            $table->text('descripcion');
+            $table->integer('id_dificultad');
+            $table->boolean('estado')->default(1);
+            $table->dateTime('fecha_creacion');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('juego_preguntas');
+    }
+};

--- a/database/migrations/2025_07_13_000002_create_juego_opciones_table.php
+++ b/database/migrations/2025_07_13_000002_create_juego_opciones_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('juego_opciones', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('id_pregunta');
+            $table->text('descripcion');
+            $table->boolean('esCorrecto');
+            $table->boolean('estado')->default(1);
+            $table->dateTime('fecha_creacion');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('juego_opciones');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,9 @@ Route::get('/niveles', [LevelController::class, 'index'])
 Route::post('/preguntas', [QuestionController::class, 'index'])
     ->middleware(TokenAuth::class);
 
+Route::post('/crear_pregunta', [QuestionController::class, 'store'])
+    ->middleware(TokenAuth::class);
+
 Route::middleware(TokenAuth::class)->group(function () {
     Route::get('/user', function (Request $request) {
         return response()->json($request->user());

--- a/tests/Feature/CreateQuestionTest.php
+++ b/tests/Feature/CreateQuestionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CreateQuestionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_question_requires_four_options_and_one_correct(): void
+    {
+        $payload = [
+            'pregunta' => '¿Cuál es la capital de Ecuador?',
+            'id_categoria' => 1,
+            'id_dificultad' => 1,
+            'opciones' => [
+                [ 'opcion' => 'Quito', 'esCorrecta' => 'true' ],
+                [ 'opcion' => 'Ambato', 'esCorrecta' => 'false' ],
+                [ 'opcion' => 'Guayaquil', 'esCorrecta' => 'false' ],
+                [ 'opcion' => 'Riobamba', 'esCorrecta' => 'false' ],
+            ],
+        ];
+
+        $response = $this->postJson('/api/crear_pregunta', $payload);
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('juego_preguntas', [
+            'descripcion' => '¿Cuál es la capital de Ecuador?',
+            'categoria' => 1,
+            'id_dificultad' => 1,
+            'estado' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add migrations for `juego_preguntas` and `juego_opciones`
- implement `store` method in `QuestionController`
- expose new `/crear_pregunta` route
- test question creation

## Testing
- `php -l app/Http/Controllers/QuestionController.php`
- `php -l database/migrations/2025_07_13_000001_create_juego_preguntas_table.php`
- `php -l database/migrations/2025_07_13_000002_create_juego_opciones_table.php`
- `php -l tests/Feature/CreateQuestionTest.php`
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68734f5167d0832f8a34aaae61b0ab8e