### PR TITLE
Allow crear_pregunta to handle multiple questions

### DIFF
--- a/tests/Feature/CreateQuestionTest.php
+++ b/tests/Feature/CreateQuestionTest.php
@@ -12,14 +12,27 @@ class CreateQuestionTest extends TestCase
     public function test_create_question_requires_four_options_and_one_correct(): void
     {
         $payload = [
-            'pregunta' => '¿Cuál es la capital de Ecuador?',
-            'id_categoria' => 1,
-            'id_dificultad' => 1,
-            'opciones' => [
-                [ 'opcion' => 'Quito', 'esCorrecta' => 'true' ],
-                [ 'opcion' => 'Ambato', 'esCorrecta' => 'false' ],
-                [ 'opcion' => 'Guayaquil', 'esCorrecta' => 'false' ],
-                [ 'opcion' => 'Riobamba', 'esCorrecta' => 'false' ],
+            [
+                'pregunta' => '¿Cuál es la capital de Ecuador?',
+                'id_categoria' => 1,
+                'id_dificultad' => 1,
+                'opciones' => [
+                    [ 'opcion' => 'Quito', 'esCorrecta' => 'true' ],
+                    [ 'opcion' => 'Ambato', 'esCorrecta' => 'false' ],
+                    [ 'opcion' => 'Guayaquil', 'esCorrecta' => 'false' ],
+                    [ 'opcion' => 'Riobamba', 'esCorrecta' => 'false' ],
+                ],
+            ],
+            [
+                'pregunta' => '¿En qué continente se encuentra Ecuador?',
+                'id_categoria' => 1,
+                'id_dificultad' => 1,
+                'opciones' => [
+                    [ 'opcion' => 'América', 'esCorrecta' => 'true' ],
+                    [ 'opcion' => 'Europa', 'esCorrecta' => 'false' ],
+                    [ 'opcion' => 'Asia', 'esCorrecta' => 'false' ],
+                    [ 'opcion' => 'África', 'esCorrecta' => 'false' ],
+                ],
             ],
         ];
 
@@ -28,6 +41,13 @@ class CreateQuestionTest extends TestCase
 
         $this->assertDatabaseHas('juego_preguntas', [
             'descripcion' => '¿Cuál es la capital de Ecuador?',
+            'categoria' => 1,
+            'id_dificultad' => 1,
+            'estado' => 1,
+        ]);
+
+        $this->assertDatabaseHas('juego_preguntas', [
+            'descripcion' => '¿En qué continente se encuentra Ecuador?',
             'categoria' => 1,
             'id_dificultad' => 1,
             'estado' => 1,


### PR DESCRIPTION
## Summary
- support bulk question creation in `QuestionController`
- update feature test to send multiple questions

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6878579a07d4832f8d0ab571547ee428