### PR TITLE
Log preguntas por sesión

### DIFF
--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use App\Models\UserSession;
+use App\Models\MatchQuestion;
 
 class QuestionController extends Controller
 {
@@ -26,6 +28,19 @@ class QuestionController extends Controller
                 $data['limit'],
             ]
         );
+
+        $token = $request->bearerToken();
+        $session = UserSession::where('token', $token)->where('estado', 1)->first();
+        if ($session) {
+            foreach ($preguntas as $preg) {
+                MatchQuestion::create([
+                    'id_sesion' => $session->id,
+                    'id_pregunta' => $preg->id,
+                    'esCorrecto' => null,
+                    'fecha_creacion' => now(),
+                ]);
+            }
+        }
 
         $resultado = [];
         foreach ($preguntas as $pregunta) {

--- a/app/Models/MatchQuestion.php
+++ b/app/Models/MatchQuestion.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MatchQuestion extends Model
+{
+    protected $table = 'partida_preguntas';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'id_sesion',
+        'id_pregunta',
+        'esCorrecto',
+        'fecha_creacion',
+    ];
+}

--- a/database/migrations/2025_07_17_000003_create_partida_preguntas_table.php
+++ b/database/migrations/2025_07_17_000003_create_partida_preguntas_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('partida_preguntas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('id_sesion');
+            $table->foreignId('id_pregunta');
+            $table->boolean('esCorrecto')->nullable();
+            $table->dateTime('fecha_creacion');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('partida_preguntas');
+    }
+};


### PR DESCRIPTION
## Summary
- create `partida_preguntas` table migration
- add `MatchQuestion` model
- store served questions in `QuestionController`

## Testing
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68785a828b94832f9cbc83b34a1602db