### PR TITLE
Fix option length

### DIFF
--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -67,11 +67,11 @@ class QuestionController extends Controller
 
             $validated = validator(['questions' => $questions], [
                 'questions' => 'required|array',
-                'questions.*.pregunta' => 'required|string',
+                'questions.*.pregunta' => 'required|string|max:255',
                 'questions.*.id_categoria' => 'required|integer',
                 'questions.*.id_dificultad' => 'required|integer',
                 'questions.*.opciones' => 'required|array|size:4',
-                'questions.*.opciones.*.opcion' => 'required|string',
+                'questions.*.opciones.*.opcion' => 'required|string|max:255',
                 'questions.*.opciones.*.esCorrecta' => 'required|in:true,false',
             ])->validate()['questions'];
 

--- a/database/migrations/2025_07_13_000002_create_juego_opciones_table.php
+++ b/database/migrations/2025_07_13_000002_create_juego_opciones_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('juego_opciones', function (Blueprint $table) {
             $table->id();
             $table->foreignId('id_pregunta');
-            $table->text('descripcion');
+            $table->string('descripcion', 255);
             $table->boolean('esCorrecto');
             $table->boolean('estado')->default(1);
             $table->dateTime('fecha_creacion');

--- a/database/migrations/2025_07_17_000003_update_juego_opciones_descripcion_column.php
+++ b/database/migrations/2025_07_17_000003_update_juego_opciones_descripcion_column.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('juego_opciones', function (Blueprint $table) {
+            $table->string('descripcion', 255)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('juego_opciones', function (Blueprint $table) {
+            $table->text('descripcion')->change();
+        });
+    }
+};

--- a/tests/Feature/QuestionValidationTest.php
+++ b/tests/Feature/QuestionValidationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class QuestionValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pregunta_and_opcion_length_validation(): void
+    {
+        $payload = [
+            'pregunta' => str_repeat('a', 256),
+            'id_categoria' => 1,
+            'id_dificultad' => 1,
+            'opciones' => [
+                ['opcion' => 'valid', 'esCorrecta' => 'true'],
+                ['opcion' => 'valid', 'esCorrecta' => 'false'],
+                ['opcion' => 'valid', 'esCorrecta' => 'false'],
+                ['opcion' => 'valid', 'esCorrecta' => 'false'],
+            ],
+        ];
+
+        $response = $this->postJson('/api/crear_pregunta', $payload);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary
- limit length of question and option text to 255 chars
- update `juego_opciones` table definition
- add migration for existing tables
- cover long-text validation

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68785bd04f88832f8bf11a68a3d31a90