### PR TITLE
Improve error response for preguntas API

### DIFF
--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -12,62 +12,68 @@ class QuestionController extends Controller
 {
     public function index(Request $request)
     {
-        $data = $request->validate([
-            'id_categoria' => 'required|integer',
-            'limit' => 'required|integer',
-            'id_dificultad' => 'required|integer',
-        ]);
+        try {
+            $data = $request->validate([
+                'id_categoria' => 'required|integer',
+                'limit' => 'required|integer',
+                'id_dificultad' => 'required|integer',
+            ]);
 
-        $preguntas = DB::select(
-            'select id, categoria, descripcion, id_dificultad, estado, fecha_creacion
-            from juego_preguntas where categoria = ? and estado = 1 and id_dificultad = ?
-            order by id_dificultad limit ?;',
-            [
-                $data['id_categoria'],
-                $data['id_dificultad'],
-                $data['limit'],
-            ]
-        );
-
-        $token = $request->bearerToken();
-        $session = UserSession::where('token', $token)->where('estado', 1)->first();
-        if ($session) {
-            foreach ($preguntas as $preg) {
-                MatchQuestion::create([
-                    'id_sesion' => $session->id,
-                    'id_pregunta' => $preg->id,
-                    'esCorrecto' => null,
-                    'fecha_creacion' => now(),
-                ]);
-            }
-        }
-
-        $resultado = [];
-        foreach ($preguntas as $pregunta) {
-            $opciones = DB::select(
-                'select id, id_pregunta, descripcion, esCorrecto, estado
-                from juego_opciones where id_pregunta = ? and estado = 1 limit 4;',
-                [$pregunta->id]
+            $preguntas = DB::select(
+                'select id, categoria, descripcion, id_dificultad, estado, fecha_creacion
+                from juego_preguntas where categoria = ? and estado = 1 and id_dificultad = ?
+                order by id_dificultad limit ?;',
+                [
+                    $data['id_categoria'],
+                    $data['id_dificultad'],
+                    $data['limit'],
+                ]
             );
 
-            $opcionesFormato = [];
-            foreach ($opciones as $index => $opcion) {
-                $opcionesFormato[] = [
-                    'orden' => (string) ($index + 1),
-                    'opcion' => $opcion->descripcion,
-                    'esCorrecta' => $opcion->esCorrecto ? 'true' : 'false',
+            $token = $request->bearerToken();
+            $session = UserSession::where('token', $token)->where('estado', 1)->first();
+            if ($session) {
+                foreach ($preguntas as $preg) {
+                    MatchQuestion::create([
+                        'id_sesion' => $session->id,
+                        'id_pregunta' => $preg->id,
+                        'esCorrecto' => null,
+                        'fecha_creacion' => now(),
+                    ]);
+                }
+            }
+
+            $resultado = [];
+            foreach ($preguntas as $pregunta) {
+                $opciones = DB::select(
+                    'select id, id_pregunta, descripcion, esCorrecto, estado
+                    from juego_opciones where id_pregunta = ? and estado = 1 limit 4;',
+                    [$pregunta->id]
+                );
+
+                $opcionesFormato = [];
+                foreach ($opciones as $index => $opcion) {
+                    $opcionesFormato[] = [
+                        'orden' => (string) ($index + 1),
+                        'opcion' => $opcion->descripcion,
+                        'esCorrecta' => $opcion->esCorrecto ? 'true' : 'false',
+                    ];
+                }
+
+                $resultado[] = [
+                    'pregunta' => $pregunta->descripcion,
+                    'id_categoria' => $pregunta->categoria,
+                    'id_dificultad' => $pregunta->id_dificultad,
+                    'opciones' => $opcionesFormato,
                 ];
             }
 
-            $resultado[] = [
-                'pregunta' => $pregunta->descripcion,
-                'id_categoria' => $pregunta->categoria,
-                'id_dificultad' => $pregunta->id_dificultad,
-                'opciones' => $opcionesFormato,
-            ];
+            return response()->json($resultado);
+        } catch (ValidationException $e) {
+            return response()->json(['errors' => $e->errors()], 422);
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
         }
-
-        return response()->json($resultado);
     }
 
     public function store(Request $request)


### PR DESCRIPTION
## Summary
- catch validation and server errors in `QuestionController::index`

## Testing
- `composer test` *(fails: vendor folder missing)*

------
https://chatgpt.com/codex/tasks/task_e_687860806dec832f8fdf4543e49b1784