### PR TITLE
Implement publicar_resultados API

### DIFF
--- a/app/Http/Controllers/ResultController.php
+++ b/app/Http/Controllers/ResultController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use App\Models\MatchResult;
+use App\Models\UserSession;
+
+class ResultController extends Controller
+{
+    public function store(Request $request)
+    {
+        try {
+            $data = $request->validate([
+                'preguntasCorrectas' => 'required|integer',
+                'preguntasIncorrectas' => 'required|integer',
+                'nickname' => 'required|string|max:200',
+            ]);
+
+            $token = $request->bearerToken();
+            $session = UserSession::where('token', $token)->where('estado', 1)->first();
+
+            if (! $session) {
+                return response()->json(['message' => 'Unauthenticated'], 401);
+            }
+
+            MatchResult::create([
+                'idPartida' => $session->id,
+                'respuestas_correctas' => $data['preguntasCorrectas'],
+                'respuestas_incorrectas' => $data['preguntasIncorrectas'],
+                'nickname' => $data['nickname'],
+                'fecha_creacion' => now(),
+            ]);
+
+            return response()->json(['message' => 'Resultados almacenados'], 201);
+        } catch (ValidationException $e) {
+            return response()->json(['errors' => $e->errors()], 422);
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/app/Models/MatchResult.php
+++ b/app/Models/MatchResult.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MatchResult extends Model
+{
+    protected $table = 'partida_resultados';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'idPartida',
+        'respuestas_correctas',
+        'respuestas_incorrectas',
+        'nickname',
+        'fecha_creacion',
+    ];
+}

--- a/database/migrations/2025_07_22_000004_create_partida_resultados_table.php
+++ b/database/migrations/2025_07_22_000004_create_partida_resultados_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('partida_resultados', function (Blueprint $table) {
+            $table->id();
+            $table->integer('idPartida')->nullable();
+            $table->integer('respuestas_correctas')->nullable();
+            $table->integer('respuestas_incorrectas')->nullable();
+            $table->string('nickname', 200)->nullable();
+            $table->dateTime('fecha_creacion')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('partida_resultados');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\LevelController;
 
 use App\Http\Controllers\QuestionController;
+use App\Http\Controllers\ResultController;
 
 
 Route::post('/login', [AuthController::class, 'login'])->middleware(CheckApiKey::class);
@@ -25,6 +26,9 @@ Route::post('/preguntas', [QuestionController::class, 'index'])
     ->middleware(TokenAuth::class);
 
 Route::post('/crear_pregunta', [QuestionController::class, 'store'])
+    ->middleware(TokenAuth::class);
+
+Route::post('/publicar_resultados', [ResultController::class, 'store'])
     ->middleware(TokenAuth::class);
 
 Route::middleware(TokenAuth::class)->group(function () {


### PR DESCRIPTION
## Summary
- add migration for `partida_resultados` table
- add `MatchResult` model
- add `ResultController` for publishing match results
- expose `/publicar_resultados` POST route

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee706d580832f9a21bf69c14919b5